### PR TITLE
feat: show exception handler function name if available

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -280,6 +280,7 @@ class SEHWidget(QWidget, UIContextNotification):
                     if all([symbol, symbol.name, not symbol.name.startswith("sub_")]):
                         self.unwind_handler_name.setText(f"{symbol.name} @ 0x{handler_addr:x}")
             else:
+                self.unwind_handler_name.clear()
                 self.unwind_exception_handler.clear()
 
     @staticmethod


### PR DESCRIPTION
Add a checkbox (disabled by default), when enabled replaces the function handler address in the "Unwind Info" section with the symbol name instead.